### PR TITLE
Analyze caringcaribou fuzzer speed

### DIFF
--- a/performance_analysis.md
+++ b/performance_analysis.md
@@ -1,0 +1,170 @@
+# Caring Caribou vs 사용자 Fuzzer 성능 비교 분석
+
+## 핵심 성능 차이점
+
+### 1. **메시지 전송 딜레이**
+
+#### Caring Caribou (fuzzer.py)
+```python
+DELAY_BETWEEN_MESSAGES = 0.01  # 10ms
+```
+- 메시지 간 단순히 0.01초만 대기
+
+#### 사용자 코드 (uds_isotp.py)
+```python
+WAIT_RESPONSE_TIME = 0.5  # 500ms
+RESET_SLEEP_TIME_SAME_ID = 0.05  # 50ms
+```
+- 매 메시지마다 최소 0.5초 이상 대기
+- ECU 리셋 후 추가 대기
+
+### 2. **메시지 전송 방식**
+
+#### Caring Caribou
+```python
+def send(self, data, arb_id=None, ...):
+    msg = can.Message(arbitration_id=arb_id, data=data, ...)
+    self.bus.send(msg)  # 즉시 전송
+```
+- CAN 버스에 직접 메시지 전송
+- **비동기 방식**: callback을 통해 응답 수신
+- 전송 후 바로 다음 메시지 준비
+
+#### 사용자 코드
+```python
+def CheckUDSMessage(self):
+    stack = isotp.CanStack(...)  # ← 매번 새로 생성
+    
+    self.StartDiagnosticMode(stack)  # 1단계
+    if self.diagnosticmodefail:
+        self.ECUReset(stack)
+        return
+    
+    self.FailDetection(stack)  # 2단계
+    if self.error_detected:
+        self.ECUReset(stack)
+        return
+    
+    self.ECUReset(stack)  # 3단계
+```
+- 매 메시지마다 **3단계 UDS 프로토콜** 수행
+- **동기 방식**: 각 단계마다 응답을 기다림
+- ISOTP 스택을 매번 새로 생성
+
+### 3. **응답 대기 방식**
+
+#### Caring Caribou
+```python
+def response_handler(msg):
+    if msg.arbitration_id != arb_id:
+        print("Received message:", msg)
+
+can_wrap.add_listener(response_handler)  # 비동기 리스너
+can_wrap.send(data=data, arb_id=arb_id)
+sleep(0.01)  # 짧은 대기 후 다음 메시지
+```
+- **비동기 callback**: 응답이 오면 자동으로 처리
+- 응답을 기다리지 않고 즉시 다음 메시지 전송
+
+#### 사용자 코드
+```python
+def wait_response(self, stack, expected_data, timeout=0.5):
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        stack.process()  # ← busy waiting
+        if stack.available():
+            response = stack.recv()
+            if response[:len(expected_data)] == bytes(expected_data):
+                return True
+        time.sleep(0.01)  # ← 매 루프마다 10ms 대기
+    return False
+```
+- **동기 busy waiting**: 응답이 올 때까지 반복 확인
+- 최대 0.5초까지 대기
+- 10ms마다 sleep → CPU 효율 낮음
+
+### 4. **메시지당 총 소요 시간 비교**
+
+#### Caring Caribou (단순 fuzzer)
+```
+1개 메시지 = 10ms (전송) + 0ms (비동기 처리)
+초당 약 100개 메시지 전송 가능
+```
+
+#### 사용자 코드 (UDS fuzzer)
+```
+1개 메시지 = 
+  - StartDiagnosticMode: 
+    * 3E 00 전송 (최대 500ms 대기) × 2회
+    * 10 03 전송 (최대 500ms 대기)
+  - FailDetection:
+    * SID + data 전송 (최대 500ms 대기)
+    * 10 01 전송 (최대 500ms 대기)
+  - ECUReset:
+    * 11 02 전송 (최대 500ms 대기) × 최대 3회
+    * 50ms 추가 대기
+
+최소: 약 1.5초 (성공 시)
+최대: 약 3-4초 (재시도 발생 시)
+초당 약 0.3~0.7개 메시지 처리
+```
+
+## 성능 차이 원인 요약
+
+1. **프로토콜 복잡도**
+   - Caring Caribou: Raw CAN 메시지 직접 전송
+   - 사용자 코드: UDS 프로토콜 (진단 세션 + 보안 + 리셋)
+
+2. **대기 시간**
+   - Caring Caribou: 10ms
+   - 사용자 코드: 1,500~4,000ms
+
+3. **처리 방식**
+   - Caring Caribou: 비동기 (callback)
+   - 사용자 코드: 동기 (busy waiting)
+
+4. **오버헤드**
+   - Caring Caribou: 최소
+   - 사용자 코드: ISOTP 스택 재생성, 다중 메시지 교환
+
+## 개선 방안
+
+### 옵션 1: 대기 시간 최소화
+```python
+WAIT_RESPONSE_TIME = 0.1  # 500ms → 100ms 감소
+```
+
+### 옵션 2: UDS 프로토콜 간소화
+- StartDiagnosticMode를 매번 수행하지 않고 세션 유지
+- 실패 시에만 ECUReset 수행
+
+### 옵션 3: 비동기 방식 도입
+```python
+# Caring Caribou 방식으로 변경
+with CanActions() as can_wrap:
+    can_wrap.add_listener(response_handler)
+    for udsid, sid, data in messages:
+        can_wrap.send([sid] + data, udsid)
+        sleep(0.01)
+```
+
+### 옵션 4: ISOTP 스택 재사용
+```python
+# 한 번만 생성
+stack = isotp.CanStack(bus=self.bus, address=addr, params=params)
+# 여러 메시지에 재사용
+```
+
+## 결론
+
+**Caring Caribou가 빠른 이유:**
+- 단순 CAN 메시지 전송 (Raw fuzzing)
+- 비동기 callback 방식
+- 최소한의 대기 시간 (10ms)
+
+**사용자 코드가 느린 이유:**
+- 복잡한 UDS 프로토콜 구현
+- 매 메시지마다 진단 세션 + 리셋 수행
+- 동기 방식의 긴 대기 시간 (500ms × 여러 번)
+
+속도를 높이려면 UDS 프로토콜을 간소화하거나, Caring Caribou처럼 Raw CAN 메시지 방식으로 변경해야 합니다.


### PR DESCRIPTION
Add a performance analysis document comparing the user's fuzzer with Caring Caribou's fuzzer to explain observed delay differences and suggest optimizations.

The user reported that their fuzzer had significant delays compared to Caring Caribou's. This document details the architectural and protocol-level differences (synchronous vs. asynchronous, UDS overhead vs. raw CAN, explicit delays) that cause the performance disparity, providing actionable insights for improvement.

---
<a href="https://cursor.com/background-agent?bcId=bc-25798ccd-b245-48d7-95e3-3623d2f8654a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25798ccd-b245-48d7-95e3-3623d2f8654a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

