### PR TITLE
Analyze caringcaribou fuzzer speed

### DIFF
--- a/debug_timing.py
+++ b/debug_timing.py
@@ -1,0 +1,75 @@
+import time
+import csv
+from collections import deque
+from module.uds_isotp import *
+from module.mutator import *
+import can
+
+def read_uds_records_from_csv(path: str):
+    records = []
+    with open(path, newline='') as f:
+        reader = csv.reader(f)
+        next(reader, None)
+        for row in reader:
+            if not row or len(row) < 3:
+                continue
+            udsid = int(row[0].strip(), 16)
+            sid = int(row[1].strip(), 16)
+            data = [int(cell.strip(), 16) for cell in row[2:] if cell.strip()]
+            depth = 0
+            records.append((udsid, sid, data, depth))
+    return records
+
+def debug_timing():
+    """타이밍 측정을 위한 디버그 함수"""
+    dq1 = deque(read_uds_records_from_csv("seed1.csv"))
+    dq2 = deque(read_uds_records_from_csv("seed2.csv"))
+    bus = can.interface.Bus(channel='can0', bustype='socketcan')
+    
+    cycle_count = 0
+    
+    while dq1 and dq2 and cycle_count < 10:  # 10사이클만 측정
+        cycle_count += 1
+        print(f"\n=== Cycle {cycle_count} ===")
+        
+        # DQ1 처리 타이밍
+        start_time = time.time()
+        udsid, sid, data, depth = dq1.popleft()
+        print(f"DQ1 popleft: {time.time() - start_time:.4f}s")
+        
+        start_time = time.time()
+        msg = UDSMessage(udsid, sid, data, depth, bus)
+        print(f"DQ1 UDSMessage creation: {time.time() - start_time:.4f}s")
+        
+        start_time = time.time()
+        fail_detection = msg.CheckUDSMessage()
+        check_time = time.time() - start_time
+        print(f"DQ1 CheckUDSMessage (UDS:{hex(udsid)}): {check_time:.4f}s")
+        
+        start_time = time.time()
+        mutated_data_list = mutator(data)
+        print(f"DQ1 mutator: {time.time() - start_time:.4f}s")
+        
+        # DQ2 처리 타이밍
+        start_time = time.time()
+        udsid, sid, data, depth = dq2.popleft()
+        print(f"DQ2 popleft: {time.time() - start_time:.4f}s")
+        
+        start_time = time.time()
+        msg = UDSMessage(udsid, sid, data, depth, bus)
+        print(f"DQ2 UDSMessage creation: {time.time() - start_time:.4f}s")
+        
+        start_time = time.time()
+        fail_detection = msg.CheckUDSMessage()
+        check_time = time.time() - start_time
+        print(f"DQ2 CheckUDSMessage (UDS:{hex(udsid)}): {check_time:.4f}s")
+        
+        start_time = time.time()
+        mutated_data_list = mutator(data)
+        print(f"DQ2 mutator: {time.time() - start_time:.4f}s")
+        
+        # 다음 사이클까지의 간격 측정
+        print(f"--- End of cycle {cycle_count} ---")
+
+if __name__ == "__main__":
+    debug_timing()

--- a/main.py
+++ b/main.py
@@ -86,15 +86,28 @@ def main():
 
     bus = can.interface.Bus(channel='can0', bustype='socketcan')
 
+    cycle_count = 0
     while dq1 and dq2: # when both queues are not empty
+        cycle_count += 1
+        cycle_start = time.time()
+        
         # Process first queue
+        dq1_start = time.time()
         udsid, sid, data, depth = dq1.popleft()
         msg = UDSMessage(udsid, sid, data, depth, bus)
         save_log(msg_idx, udsid, sid, data)
         msg_idx += 1
 
+        check_start = time.time()
         fail_detection = msg.CheckUDSMessage()
+        check_time = time.time() - check_start
+        
+        mutate_start = time.time()
         mutated_data_list = mutator(data)
+        mutate_time = time.time() - mutate_start
+        
+        dq1_total = time.time() - dq1_start
+        print(f"Cycle {cycle_count} - DQ1 ({hex(udsid)}): Total={dq1_total:.3f}s, Check={check_time:.3f}s, Mutate={mutate_time:.3f}s")
 
         if fail_detection:
             print(f"Fail Detected! {msg_idx}: [{hex(udsid)}][{hex(sid)}] [Depth: {depth}] [{data}]")
@@ -106,14 +119,27 @@ def main():
                 for mutated_data in mutated_data_list:
                     dq1.append((udsid, sid, mutated_data, depth + 1))
 
+        # Gap between DQ1 and DQ2
+        gap_start = time.time()
+        
         # process second queue
+        dq2_start = time.time()
         udsid, sid, data, depth = dq2.popleft()
         msg = UDSMessage(udsid, sid, data, depth, bus)
         save_log(msg_idx, udsid, sid, data)
         msg_idx += 1
 
+        check_start = time.time()
         fail_detection = msg.CheckUDSMessage()
+        check_time = time.time() - check_start
+        
+        mutate_start = time.time()
         mutated_data_list = mutator(data)
+        mutate_time = time.time() - mutate_start
+        
+        dq2_total = time.time() - dq2_start
+        gap_time = dq2_start - gap_start
+        print(f"Cycle {cycle_count} - DQ2 ({hex(udsid)}): Total={dq2_total:.3f}s, Check={check_time:.3f}s, Mutate={mutate_time:.3f}s, Gap={gap_time:.3f}s")
 
         if fail_detection:
             print(f"Fail Detected! {msg_idx}: [{hex(udsid)}][{hex(sid)}] [Depth: {depth}] [{data}]")
@@ -124,6 +150,10 @@ def main():
             if depth < MAX_DEPTH:
                 for mutated_data in mutated_data_list:
                     dq2.append((udsid, sid, mutated_data, depth + 1))
+        
+        cycle_total = time.time() - cycle_start
+        print(f"Cycle {cycle_count} - Total cycle time: {cycle_total:.3f}s")
+        print("=" * 60)
 
 
     if dq1:


### PR DESCRIPTION
Add `debug_timing.py` script to measure fuzzer message processing times.

This script helps diagnose performance bottlenecks, especially the perceived delays when switching between message queues, by timing `popleft`, `UDSMessage` creation, `CheckUDSMessage`, and `mutator` steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0bf2b68-0780-4904-93e0-0326777835e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0bf2b68-0780-4904-93e0-0326777835e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

